### PR TITLE
Upload page build as CI artifact

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,3 +30,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+
+      - name: Upload page build as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: scverse.github.io
+          path: ./public


### PR DESCRIPTION
allows to easily preview changes even without having a local testing environment set-up.