### PR TITLE
Fix social buttons on mobile landing page

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -286,7 +286,6 @@ body {
                     margin-top: 10%;
                     @media (max-device-width: 40rem) {
                         margin-top: 10%;
-                        max-height: 20rem;
                     }
                     max-width: $maxwidthwide;
                     border-radius: 1rem;


### PR DESCRIPTION
Fixes this:

<img width="309" alt="image" src="https://user-images.githubusercontent.com/8238804/167499161-c05378ca-667d-4390-ad13-9e92676b3fe1.png">


By making removing the max height of the containing div