### PR TITLE
Correct ecosystem section link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -51,7 +51,7 @@ text = """\
 [ecosystem]
 
 text = """\
-A broader ecosystem of packages builds on the **scverse** core packages. [These tools](/packages#ecosystem) implement models and analytical approaches to tackle challenges in spatial omics, regulatory genomics, trajectory inference, visualization, and more."""
+A broader ecosystem of packages builds on the **scverse** core packages. [These tools](/packages/#ecosystem) implement models and analytical approaches to tackle challenges in spatial omics, regulatory genomics, trajectory inference, visualization, and more."""
 
 # Team
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,7 @@
               <p class="section-paragraph">
                 {{ .Params.ecosystem.text | markdownify }}
               </p>
-              <a href="/packages#ecosystem">
+              <a href="/packages/#ecosystem">
                 <div class="more">Continue to scverse ecosystem</div>
               </a>
             </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -37,7 +37,7 @@
                 <a class="dropdown-item" href="/packages#core-packages">Core</a>
               </li>
               <li>
-                <a class="dropdown-item" href="/packages#ecosystem">Ecosystem</a>
+                <a class="dropdown-item" href="/packages/#ecosystem">Ecosystem</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Sometimes when I clicked on links to the ecosystem section it didn't work at:

scverse.org/packages#ecosystem

It seems to always work at:

scverse.org/packages/#ecosystem

So I've switched to using the later now.