### PR TITLE
Allow packages with no logo

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -48,6 +48,7 @@ description = "Foundational tools for single-cell omics data analysis"
 	name = "SnapATAC2"
 	description = "Single-cell ATAC analysis framework"
 	url = "https://scverse.org/SnapATAC2/"
+        no_icon = true
 
 [[packages]]
 	name = "rapids-singlecell"

--- a/layouts/partials/main/packages.html
+++ b/layouts/partials/main/packages.html
@@ -8,10 +8,13 @@
           <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 py-3">
             <div class="card border-0 bh-light px-3" id="{{ .name }}-tile">
               <div class="package-icon my-4">
-                {{ if not .no_icon }}
-                  <img src="img/icons/{{ lower .name }}.svg" alt="Logo for {{ .name }}" />
-                {{ else }}
+                {{ $exists := fileExists (printf "static/img/icons/%s.svg" .name) }}
+                {{ if .no_icon }}
                   <img />
+                {{ else if $exists }}
+                  <img src="img/icons/{{ .name }}.svg" alt="Logo for {{ .name }}" />
+                {{ else }}
+                  {{ errorf "No icon or .no_icon for package %q" .name }}
                 {{ end }}
               </div>
               <div class="card-body package-text p-2">

--- a/layouts/partials/main/packages.html
+++ b/layouts/partials/main/packages.html
@@ -8,7 +8,11 @@
           <div class="col-xs-12 col-sm-12 col-md-12 col-lg-6 py-3">
             <div class="card border-0 bh-light px-3" id="{{ .name }}-tile">
               <div class="package-icon my-4">
-                <img src="img/icons/{{ .name }}.svg" alt="Logo for {{ .name }}" />
+                {{ if not .no_icon }}
+                  <img src="img/icons/{{ lower .name }}.svg" alt="Logo for {{ .name }}" />
+                {{ else }}
+                  <img />
+                {{ end }}
               </div>
               <div class="card-body package-text p-2">
                 <a


### PR DESCRIPTION
`no_icon = true` can now be added to the package information to render them appropriately on the main page.

Package names can also be capitalized now as their names will be converted to lowercase to fetch the correct icon files based on the package name.
Though I think all-lowercase is something we should keep, maybe in the case of `snapatac2` vs `SnapATAC2` it is a bit too much.