### PR TITLE
redirect /morphology2026/ to /cellpainting2026/

### DIFF
--- a/static/morphology2026/index.html
+++ b/static/morphology2026/index.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Moved &mdash; scverse x cellpainting 2026</title>
+  <title>scverse x cellpainting 2026</title>
+  <script>window.location.replace("https://scverse.org/cellpainting2026/" + window.location.search + window.location.hash);</script>
   <meta http-equiv="refresh" content="0; url=https://scverse.org/cellpainting2026/">
   <link rel="canonical" href="https://scverse.org/cellpainting2026/">
   <meta name="robots" content="noindex">
 </head>
 <body>
-  <p>This hackathon has been renamed to <strong>scverse x cellpainting 2026</strong>. Redirecting to <a href="https://scverse.org/cellpainting2026/">scverse.org/cellpainting2026/</a>&hellip;</p>
+  <p>Redirecting to <a href="https://scverse.org/cellpainting2026/">scverse.org/cellpainting2026/</a>&hellip;</p>
 </body>
 </html>

--- a/static/morphology2026/index.html
+++ b/static/morphology2026/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Moved &mdash; scverse x cellpainting 2026</title>
+  <meta http-equiv="refresh" content="0; url=https://scverse.org/cellpainting2026/">
+  <link rel="canonical" href="https://scverse.org/cellpainting2026/">
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <p>This hackathon has been renamed to <strong>scverse x cellpainting 2026</strong>. Redirecting to <a href="https://scverse.org/cellpainting2026/">scverse.org/cellpainting2026/</a>&hellip;</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a static meta-refresh stub at `/morphology2026/` so visitors hitting the old hackathon URL are forwarded to the renamed event page at `/cellpainting2026/`
- No content/data changes elsewhere