### PR TITLE
Add Cell Painting 2026 hackathon; direct event links; lowercase scverse

### DIFF
--- a/content/events/2022_05_hackathon.md
+++ b/content/events/2022_05_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2022-05 Munich"
+title = "scverse Hackathon 2022-05 Munich"
 date = 2022-05-02T00:00:05+01:00
 description = "Hackathon on scverse cookiecutter template"
 draft = false

--- a/content/events/2022_12_hackathon.md
+++ b/content/events/2022_12_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2022-12 Innsbruck"
+title = "scverse Hackathon 2022-12 Innsbruck"
 date = 2022-12-08T00:00:05+01:00
 description = "Hackathon on documentation"
 draft = false

--- a/content/events/2023_04_hackathon.md
+++ b/content/events/2023_04_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2023-04 Heidelberg"
+title = "scverse Hackathon 2023-04 Heidelberg"
 date = 2023-04-26T00:00:05+01:00
 description = "Hackathon on interoperability and knowledge representation"
 draft = false

--- a/content/events/2023_11_hackathon.md
+++ b/content/events/2023_11_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2023-11 Cambridge"
+title = "scverse Hackathon 2023-11 Cambridge"
 date = 2023-11-26T00:00:05+01:00
 description = "Hackathon on multi-condition analysis and ML data loaders"
 draft = false

--- a/content/events/2024_04_hackathon.md
+++ b/content/events/2024_04_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2024-04 Boston"
+title = "scverse Hackathon 2024-04 Boston"
 date = 2024-04-02T00:00:05+01:00
 description = "Hackathon on interactive analysis single-cell and spatial genomics"
 draft = false

--- a/content/events/2024_09_conference.md
+++ b/content/events/2024_09_conference.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Conference 2024-09 Munich"
+title = "scverse Conference 2024-09 Munich"
 date = 2024-09-10T00:00:05+01:00
 description = "scverse conference"
 draft = false

--- a/content/events/2025_03_hackathon.md
+++ b/content/events/2025_03_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2025-03 Paris"
+title = "scverse Hackathon 2025-03 Paris"
 date = 2025-03-17T00:00:05+01:00
 description = "scverse x Owkin hackathon"
 draft = false

--- a/content/events/2025_11_conference.md
+++ b/content/events/2025_11_conference.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Conference 2025-11 Stanford"
+title = "scverse Conference 2025-11 Stanford"
 date = 2025-11-17T00:00:00+01:00
 description = "scverse conference"
 draft = false

--- a/content/events/2026_03_hackathon.md
+++ b/content/events/2026_03_hackathon.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Hackathon 2026-03 Berlin"
+title = "scverse Hackathon 2026-03 Berlin"
 date = 2026-03-30T00:00:05+01:00
 description = "scverse x proteomics hackathon"
 draft = false

--- a/content/events/2026_09_cellpainting.md
+++ b/content/events/2026_09_cellpainting.md
@@ -1,0 +1,12 @@
++++
+title = "Scverse x Cell Painting Hackathon 2026-09 Berlin"
+date = 2026-09-02T00:00:00+02:00
+description = "scverse × Cell Painting hackathon"
+draft = false
++++
+
+Join us for the scverse × Cell Painting hackathon taking place from **Wednesday, September 2** to **Friday, September 4** at the **Max Delbrück Center, Campus Berlin-Buch, Berlin, Germany**.
+
+This hackathon unites the scverse, CytoData Society, and EU-OPENSCREEN communities for three days of collaborative development, bridging scverse and Cell Painting communities at the intersection of image-based profiling, phenomics, and single-cell perturbation analysis.
+
+[Visit the dedicated event page for more details](https://scverse.org/cellpainting2026/)

--- a/content/events/2026_09_cellpainting.md
+++ b/content/events/2026_09_cellpainting.md
@@ -1,7 +1,8 @@
 +++
-title = "Scverse x Cell Painting Hackathon 2026-09 Berlin"
+title = "scverse x Cell Painting Hackathon 2026-09 Berlin"
 date = 2026-09-02T00:00:00+02:00
 description = "scverse × Cell Painting hackathon"
+link = "https://scverse.org/cellpainting2026/"
 draft = false
 +++
 

--- a/content/events/2026_10_conference.md
+++ b/content/events/2026_10_conference.md
@@ -1,5 +1,5 @@
 +++
-title = "Scverse Conference 2026-10 Copenhagen"
+title = "scverse Conference 2026-10 Copenhagen"
 date = 2026-10-12T00:00:00+01:00
 description = "scverse conference"
 +++

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -4,7 +4,7 @@ title: Events
 
 ## Open community meeting
 
-Scverse community meetings happen **every second Tuesday at 6pm CET** and are open to
+scverse community meetings happen **every second Tuesday at 6pm CET** and are open to
 everyone! If you are new to scverse, these meetings are a great way to get to know
 the people behind the project. 
 

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -7,7 +7,7 @@
   {{ with where .Data.Pages "Date.Unix" ">" now.Unix }}
     <h2>Upcoming events</h2>
     {{ range . }}
-      <a href="{{ .RelPermalink }}">
+      <a href="{{ with .Params.link }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}">
         <article class="page-item">
           <div class="page-item-date">
             <span>{{ .Date.Format "January 02, 2006" }}</span>
@@ -27,7 +27,7 @@
 {{ define "main" }}
   <h2>Past events</h2>
   {{ range where .Data.Pages "Date.Unix" "<=" now.Unix }}
-    <a href="{{ .RelPermalink }}">
+    <a href="{{ with .Params.link }}{{ . }}{{ else }}{{ .RelPermalink }}{{ end }}">
       <article class="page-item">
         <div class="page-item-date">
           <span>{{ .Date.Format "January 02, 2006" }}</span>


### PR DESCRIPTION
## Changes

- **Add event** — scverse × Cell Painting 2026 hackathon (Sept 2–4, 2026, Max Delbrück Center, Berlin) added to `/events/`. Appears under **Upcoming events**.
- **Direct external links** — added a `link` frontmatter field; when set, the events list links straight to that URL instead of the generated Hugo page. Used here to jump directly to https://scverse.org/cellpainting2026/. Existing events without the field are unchanged.
- **Lowercase scverse** — replaced "Scverse" with "scverse" across all event entries and the meetings blurb.